### PR TITLE
fix: run code-server as the appropriate user

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
         features:
           - code-server
         baseImage:
+          - fedora:latest
           - debian:latest
           - ubuntu:latest
           - mcr.microsoft.com/devcontainers/base:ubuntu

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -22,7 +22,7 @@ cat > /usr/local/bin/code-server-entrypoint \
 #!/usr/bin/env bash
 set -e
 
-runuser -l $_REMOTE_USER -c 'code-server --bind-addr "$HOST:$PORT" \$ARGS'
+su $_REMOTE_USER -c 'code-server --bind-addr "$HOST:$PORT" \$ARGS'
 EOF
 
 chmod +x /usr/local/bin/code-server-entrypoint

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -22,7 +22,7 @@ cat > /usr/local/bin/code-server-entrypoint \
 #!/usr/bin/env bash
 set -e
 
-code-server --bind-addr "$HOST:$PORT" \$ARGS
+runuser -l $_REMOTE_USER -c 'code-server --bind-addr "$HOST:$PORT" \$ARGS'
 EOF
 
 chmod +x /usr/local/bin/code-server-entrypoint

--- a/test/code-server/code-server-extensions.sh
+++ b/test/code-server/code-server-extensions.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 # Feature-specific tests
 check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
-check "code-server listening" sudo lsof -i "@0.0.0.0:8080"
+check "code-server listening" lsof -i "@0.0.0.0:8080"
 
 extensions=$(sudo code-server --list-extensions)
 

--- a/test/code-server/code-server-install-version.sh
+++ b/test/code-server/code-server-install-version.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 # Feature-specific tests
 check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
-check "code-server listening" sudo lsof -i "@0.0.0.0:8080"
+check "code-server listening" lsof -i "@0.0.0.0:8080"
 
 version=$(code-server --version)
 check "code-server is correct version" grep '4.98.0\>' <<<"$version"

--- a/test/code-server/code-server-modified-host.sh
+++ b/test/code-server/code-server-modified-host.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 # Feature-specific tests
 check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
-check "code-server listening" sudo lsof -i "@0.0.0.0:8080"
+check "code-server listening" lsof -i "@0.0.0.0:8080"
 
 # Report results
 reportResults

--- a/test/code-server/code-server-modified-port.sh
+++ b/test/code-server/code-server-modified-port.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 # Feature-specific tests
 check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
-check "code-server listening" sudo lsof -i "@127.0.0.1:1234"
+check "code-server listening" lsof -i "@127.0.0.1:1234"
 
 # Report results
 reportResults

--- a/test/code-server/test.sh
+++ b/test/code-server/test.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 # Feature-specific tests
 check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
-check "code-server listening" sudo lsof -i "@127.0.0.1:8080"
+check "code-server listening" lsof -i "@127.0.0.1:8080"
 
 # Report results
 reportResults


### PR DESCRIPTION
Rather than run code-server as root, we instead run it as the appropriate user.