### PR TITLE
feat: add `--disable-*` options

### DIFF
--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -16,6 +16,13 @@ VS Code in the browser
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
 | auth | The type of authentication to use. When 'password' is selected, code-server will auto-generate a password. 'none' disables authentication entirely. | string | password |
+| disableFileDownloads | Disable file downloads from Code. When enabled, users will not be able to download files from the editor. | boolean | false |
+| disableFileUploads | Disable file uploads to Code. When enabled, users will not be able to upload files to the editor. | boolean | false |
+| disableGettingStartedOverride | Disable the coder/coder override in the Help: Getting Started page. | boolean | false |
+| disableProxy | Disable domain and path proxy routes. | boolean | false |
+| disableTelemetry | Disable telemetry reporting. | boolean | false |
+| disableUpdateCheck | Disable update check. Without this flag, code-server checks every 6 hours against the latest github release and notifies once a week when updates are available. | boolean | false |
+| disableWorkspaceTrust | Disable Workspace Trust feature. This only affects the current session. | boolean | false |
 | extensions | Comma-separated list of VS Code extensions to install. Format: 'publisher.extension[@version]' (e.g., 'ms-python.python,ms-azuretools.vscode-docker'). | string | - |
 | host | The address to bind to for the code-server. Use '0.0.0.0' to listen on all interfaces. | string | 127.0.0.1 |
 | port | The port to bind to for the code-server. | string | 8080 |

--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -21,7 +21,7 @@ VS Code in the browser
 | disableGettingStartedOverride | Disable the coder/coder override in the Help: Getting Started page. | boolean | false |
 | disableProxy | Disable domain and path proxy routes. | boolean | false |
 | disableTelemetry | Disable telemetry reporting. | boolean | false |
-| disableUpdateCheck | Disable update check. Without this flag, code-server checks every 6 hours against the latest github release and notifies once a week when updates are available. | boolean | false |
+| disableUpdateCheck | Disable update check. Without this flag, code-server checks every 6 hours against the latest GitHub release and notifies once a week when updates are available. | boolean | false |
 | disableWorkspaceTrust | Disable Workspace Trust feature. This only affects the current session. | boolean | false |
 | extensions | Comma-separated list of VS Code extensions to install. Format: 'publisher.extension[@version]' (e.g., 'ms-python.python,ms-azuretools.vscode-docker'). | string | - |
 | host | The address to bind to for the code-server. Use '0.0.0.0' to listen on all interfaces. | string | 127.0.0.1 |

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -10,6 +10,41 @@
             "default": "password",
             "description": "The type of authentication to use. When 'password' is selected, code-server will auto-generate a password. 'none' disables authentication entirely."
         },
+        "disableFileDownloads": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disable file downloads from Code. When enabled, users will not be able to download files from the editor."
+        },
+        "disableFileUploads": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disable file uploads to Code. When enabled, users will not be able to upload files to the editor."
+        },
+        "disableGettingStartedOverride": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disable the coder/coder override in the Help: Getting Started page."
+        },
+        "disableProxy": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disable domain and path proxy routes."
+        },
+        "disableTelemetry": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disable telemetry reporting."
+        },
+        "disableUpdateCheck": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disable update check. Without this flag, code-server checks every 6 hours against the latest github release and notifies once a week when updates are available."
+        },
+        "disableWorkspaceTrust": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disable Workspace Trust feature. This only affects the current session."
+        },
         "extensions": {
             "type": "string",
             "default": "",

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -38,7 +38,7 @@
         "disableUpdateCheck": {
             "type": "boolean",
             "default": false,
-            "description": "Disable update check. Without this flag, code-server checks every 6 hours against the latest github release and notifies once a week when updates are available."
+            "description": "Disable update check. Without this flag, code-server checks every 6 hours against the latest GitHub release and notifies once a week when updates are available."
         },
         "disableWorkspaceTrust": {
             "type": "boolean",

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -23,7 +23,6 @@ if [[ -n $WORKSPACE ]]; then
     CODE_SERVER_WORKSPACE="$WORKSPACE"
 fi
 
-# Build disable flags based on boolean options
 DISABLE_FLAGS=""
 
 if [[ "$DISABLEFILEDOWNLOADS" == "true" ]]; then

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -23,12 +23,43 @@ if [[ -n $WORKSPACE ]]; then
     CODE_SERVER_WORKSPACE="$WORKSPACE"
 fi
 
+# Build disable flags based on boolean options
+DISABLE_FLAGS=""
+
+if [[ "$DISABLEFILEDOWNLOADS" == "true" ]]; then
+    DISABLE_FLAGS="$DISABLE_FLAGS --disable-file-downloads"
+fi
+
+if [[ "$DISABLEFILEUPLOADS" == "true" ]]; then
+    DISABLE_FLAGS="$DISABLE_FLAGS --disable-file-uploads"
+fi
+
+if [[ "$DISABLEGETTINGSTARTEDOVERRIDE" == "true" ]]; then
+    DISABLE_FLAGS="$DISABLE_FLAGS --disable-getting-started-override"
+fi
+
+if [[ "$DISABLEPROXY" == "true" ]]; then
+    DISABLE_FLAGS="$DISABLE_FLAGS --disable-proxy"
+fi
+
+if [[ "$DISABLETELEMETRY" == "true" ]]; then
+    DISABLE_FLAGS="$DISABLE_FLAGS --disable-telemetry"
+fi
+
+if [[ "$DISABLEUPDATECHECK" == "true" ]]; then
+    DISABLE_FLAGS="$DISABLE_FLAGS --disable-update-check"
+fi
+
+if [[ "$DISABLEWORKSPACETRUST" == "true" ]]; then
+    DISABLE_FLAGS="$DISABLE_FLAGS --disable-workspace-trust"
+fi
+
 cat > /usr/local/bin/code-server-entrypoint \
 << EOF
 #!/usr/bin/env bash
 set -e
 
-su $_REMOTE_USER -c 'code-server --auth "$AUTH" --bind-addr "$HOST:$PORT" "$CODE_SERVER_WORKSPACE"'
+su $_REMOTE_USER -c 'code-server --auth "$AUTH" --bind-addr "$HOST:$PORT" $DISABLE_FLAGS "$CODE_SERVER_WORKSPACE"'
 EOF
 
 chmod +x /usr/local/bin/code-server-entrypoint

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -23,34 +23,34 @@ if [[ -n $WORKSPACE ]]; then
     CODE_SERVER_WORKSPACE="$WORKSPACE"
 fi
 
-DISABLE_FLAGS=""
+DISABLE_FLAGS=()
 
 if [[ "$DISABLEFILEDOWNLOADS" == "true" ]]; then
-    DISABLE_FLAGS="$DISABLE_FLAGS --disable-file-downloads"
+    DISABLE_FLAGS+=(--disable-file-downloads)
 fi
 
 if [[ "$DISABLEFILEUPLOADS" == "true" ]]; then
-    DISABLE_FLAGS="$DISABLE_FLAGS --disable-file-uploads"
+    DISABLE_FLAGS+=(--disable-file-uploads)
 fi
 
 if [[ "$DISABLEGETTINGSTARTEDOVERRIDE" == "true" ]]; then
-    DISABLE_FLAGS="$DISABLE_FLAGS --disable-getting-started-override"
+    DISABLE_FLAGS+=(--disable-getting-started-override)
 fi
 
 if [[ "$DISABLEPROXY" == "true" ]]; then
-    DISABLE_FLAGS="$DISABLE_FLAGS --disable-proxy"
+    DISABLE_FLAGS+=(--disable-proxy)
 fi
 
 if [[ "$DISABLETELEMETRY" == "true" ]]; then
-    DISABLE_FLAGS="$DISABLE_FLAGS --disable-telemetry"
+    DISABLE_FLAGS+=(--disable-telemetry)
 fi
 
 if [[ "$DISABLEUPDATECHECK" == "true" ]]; then
-    DISABLE_FLAGS="$DISABLE_FLAGS --disable-update-check"
+    DISABLE_FLAGS+=(--disable-update-check)
 fi
 
 if [[ "$DISABLEWORKSPACETRUST" == "true" ]]; then
-    DISABLE_FLAGS="$DISABLE_FLAGS --disable-workspace-trust"
+    DISABLE_FLAGS+=(--disable-workspace-trust)
 fi
 
 cat > /usr/local/bin/code-server-entrypoint \
@@ -58,7 +58,7 @@ cat > /usr/local/bin/code-server-entrypoint \
 #!/usr/bin/env bash
 set -e
 
-su $_REMOTE_USER -c 'code-server --auth "$AUTH" --bind-addr "$HOST:$PORT" $DISABLE_FLAGS "$CODE_SERVER_WORKSPACE"'
+su $_REMOTE_USER -c 'code-server --auth "$AUTH" --bind-addr "$HOST:$PORT" ${DISABLE_FLAGS[*]} "$CODE_SERVER_WORKSPACE"'
 EOF
 
 chmod +x /usr/local/bin/code-server-entrypoint

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -58,7 +58,9 @@ cat > /usr/local/bin/code-server-entrypoint \
 #!/usr/bin/env bash
 set -e
 
-su $_REMOTE_USER -c 'code-server --auth "$AUTH" --bind-addr "$HOST:$PORT" ${DISABLE_FLAGS[*]} "$CODE_SERVER_WORKSPACE"'
+$(declare -p DISABLE_FLAGS)
+
+su $_REMOTE_USER -c 'code-server --auth "$AUTH" --bind-addr "$HOST:$PORT" "\${DISABLE_FLAGS[@]}" "$CODE_SERVER_WORKSPACE"'
 EOF
 
 chmod +x /usr/local/bin/code-server-entrypoint

--- a/test/code-server/code-server-disable-file-downloads.sh
+++ b/test/code-server/code-server-disable-file-downloads.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server disable-file-downloads" grep $'\'code-server.* --disable-file-downloads .*' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-disable-file-downloads.sh
+++ b/test/code-server/code-server-disable-file-downloads.sh
@@ -9,7 +9,7 @@ check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@127.0.0.1:8080"
 
-check "code-server disable-file-downloads" grep $'\'code-server.* --disable-file-downloads .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-file-downloads" grep '"--disable-file-downloads"' < /usr/local/bin/code-server-entrypoint
 
 # Report results
 reportResults

--- a/test/code-server/code-server-disable-file-uploads.sh
+++ b/test/code-server/code-server-disable-file-uploads.sh
@@ -9,7 +9,7 @@ check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@127.0.0.1:8080"
 
-check "code-server disable-file-uploads" grep $'\'code-server.* --disable-file-uploads .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-file-uploads" grep '"--disable-file-uploads"' < /usr/local/bin/code-server-entrypoint
 
 # Report results
 reportResults

--- a/test/code-server/code-server-disable-file-uploads.sh
+++ b/test/code-server/code-server-disable-file-uploads.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server disable-file-uploads" grep $'\'code-server.* --disable-file-uploads .*' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-disable-getting-started-override.sh
+++ b/test/code-server/code-server-disable-getting-started-override.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server disable-getting-started-override" grep $'\'code-server.* --disable-getting-started-override .*' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-disable-getting-started-override.sh
+++ b/test/code-server/code-server-disable-getting-started-override.sh
@@ -9,7 +9,7 @@ check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@127.0.0.1:8080"
 
-check "code-server disable-getting-started-override" grep $'\'code-server.* --disable-getting-started-override .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-getting-started-override" grep '"--disable-getting-started-override"' < /usr/local/bin/code-server-entrypoint
 
 # Report results
 reportResults

--- a/test/code-server/code-server-disable-multiple-options.sh
+++ b/test/code-server/code-server-disable-multiple-options.sh
@@ -9,14 +9,14 @@ check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@127.0.0.1:8080"
 
-# Check for all three flags we enabled in this scenario
-check "code-server disable-file-downloads" grep $'\'code-server.* --disable-file-downloads .*' < /usr/local/bin/code-server-entrypoint
-check "code-server disable-file-uploads" grep $'\'code-server.* --disable-file-uploads .*' < /usr/local/bin/code-server-entrypoint
-check "code-server disable-getting-started-override" grep $'\'code-server.* --disable-getting-started-override .*' < /usr/local/bin/code-server-entrypoint
-check "code-server disable-proxy" grep $'\'code-server.* --disable-proxy .*' < /usr/local/bin/code-server-entrypoint
-check "code-server disable-telemetry" grep $'\'code-server.* --disable-telemetry .*' < /usr/local/bin/code-server-entrypoint
-check "code-server disable-update-check" grep $'\'code-server.* --disable-update-check .*' < /usr/local/bin/code-server-entrypoint
-check "code-server disable-workspace-trust" grep $'\'code-server.* --disable-workspace-trust .*' < /usr/local/bin/code-server-entrypoint
+# Check for all flags we enabled in this scenario
+check "code-server disable-file-downloads" grep '"--disable-file-downloads"' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-file-uploads" grep '"--disable-file-uploads"' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-getting-started-override" grep '"--disable-getting-started-override"' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-proxy" grep '"--disable-proxy"' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-telemetry" grep '"--disable-telemetry"' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-update-check" grep '"--disable-update-check"' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-workspace-trust" grep '"--disable-workspace-trust"' < /usr/local/bin/code-server-entrypoint
 
 # Report results
 reportResults

--- a/test/code-server/code-server-disable-multiple-options.sh
+++ b/test/code-server/code-server-disable-multiple-options.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+# Check for all three flags we enabled in this scenario
+check "code-server disable-file-downloads" grep $'\'code-server.* --disable-file-downloads .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-file-uploads" grep $'\'code-server.* --disable-file-uploads .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-getting-started-override" grep $'\'code-server.* --disable-getting-started-override .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-proxy" grep $'\'code-server.* --disable-proxy .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-telemetry" grep $'\'code-server.* --disable-telemetry .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-update-check" grep $'\'code-server.* --disable-update-check .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-workspace-trust" grep $'\'code-server.* --disable-workspace-trust .*' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-disable-proxy.sh
+++ b/test/code-server/code-server-disable-proxy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server disable-proxy" grep $'\'code-server.* --disable-proxy .*' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-disable-proxy.sh
+++ b/test/code-server/code-server-disable-proxy.sh
@@ -9,7 +9,7 @@ check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@127.0.0.1:8080"
 
-check "code-server disable-proxy" grep $'\'code-server.* --disable-proxy .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-proxy" grep '"--disable-proxy"' < /usr/local/bin/code-server-entrypoint
 
 # Report results
 reportResults

--- a/test/code-server/code-server-disable-telemetry.sh
+++ b/test/code-server/code-server-disable-telemetry.sh
@@ -9,7 +9,7 @@ check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@127.0.0.1:8080"
 
-check "code-server disable-telemetry" grep $'\'code-server.* --disable-telemetry .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-telemetry" grep '"--disable-telemetry"' < /usr/local/bin/code-server-entrypoint
 
 # Report results
 reportResults

--- a/test/code-server/code-server-disable-telemetry.sh
+++ b/test/code-server/code-server-disable-telemetry.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server disable-telemetry" grep $'\'code-server.* --disable-telemetry .*' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-disable-update-check.sh
+++ b/test/code-server/code-server-disable-update-check.sh
@@ -9,7 +9,7 @@ check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@127.0.0.1:8080"
 
-check "code-server disable-update-check" grep $'\'code-server.* --disable-update-check .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-update-check" grep '"--disable-update-check"' < /usr/local/bin/code-server-entrypoint
 
 # Report results
 reportResults

--- a/test/code-server/code-server-disable-update-check.sh
+++ b/test/code-server/code-server-disable-update-check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server disable-update-check" grep $'\'code-server.* --disable-update-check .*' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-disable-workspace-trust.sh
+++ b/test/code-server/code-server-disable-workspace-trust.sh
@@ -9,7 +9,7 @@ check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@127.0.0.1:8080"
 
-check "code-server disable-workspace-trust" grep $'\'code-server.* --disable-workspace-trust .*' < /usr/local/bin/code-server-entrypoint
+check "code-server disable-workspace-trust" grep '"--disable-workspace-trust"' < /usr/local/bin/code-server-entrypoint
 
 # Report results
 reportResults

--- a/test/code-server/code-server-disable-workspace-trust.sh
+++ b/test/code-server/code-server-disable-workspace-trust.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server disable-workspace-trust" grep $'\'code-server.* --disable-workspace-trust .*' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/scenarios.json
+++ b/test/code-server/scenarios.json
@@ -54,5 +54,75 @@
                 "auth": "password"
             }
         }
+    },
+    "code-server-disable-file-downloads": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "disableFileDownloads": true
+            }
+        }
+    },
+    "code-server-disable-file-uploads": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "disableFileUploads": true
+            }
+        }
+    },
+    "code-server-disable-getting-started-override": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "disableGettingStartedOverride": true
+            }
+        }
+    },
+    "code-server-disable-proxy": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "disableProxy": true
+            }
+        }
+    },
+    "code-server-disable-telemetry": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "disableTelemetry": true
+            }
+        }
+    },
+    "code-server-disable-update-check": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "disableUpdateCheck": true
+            }
+        }
+    },
+    "code-server-disable-workspace-trust": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "disableWorkspaceTrust": true
+            }
+        }
+    },
+    "code-server-disable-multiple-options": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "disableFileDownloads": true,
+                "disableFileUploads": true,
+                "disableGettingStartedOverride": true,
+                "disableProxy": true,
+                "disableTelemetry": true,
+                "disableUpdateCheck": true,
+                "disableWorkspaceTrust": true
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds several new configuration options to the code-server devcontainer feature that allow users to disable specific functionality:

- `disableFileDownloads`: Prevents users from downloading files from the editor
- `disableFileUploads`: Prevents users from uploading files to the editor
- `disableGettingStartedOverride`: Disables the coder/coder override in Help: Getting Started
- `disableProxy`: Disables domain and path proxy routes
- `disableTelemetry`: Disables telemetry reporting
- `disableUpdateCheck`: Disables the update check that runs every 6 hours
- `disableWorkspaceTrust`: Disables the Workspace Trust feature for the current session