### PR TITLE
feat: add `--cert*` options

### DIFF
--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -16,6 +16,9 @@ VS Code in the browser
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
 | auth | The type of authentication to use. When 'password' is selected, code-server will auto-generate a password. 'none' disables authentication entirely. | string | password |
+| cert | Path to certificate. A self signed certificate is generated if none is provided. | string | - |
+| certHost | hostname to use when generating a self signed certificate. | string | - |
+| certKey | path to certificate key when using non-generated cert. | string | - |
 | disableFileDownloads | Disable file downloads from Code. When enabled, users will not be able to download files from the editor. | boolean | false |
 | disableFileUploads | Disable file uploads to Code. When enabled, users will not be able to upload files to the editor. | boolean | false |
 | disableGettingStartedOverride | Disable the coder/coder override in the Help: Getting Started page. | boolean | false |

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -10,6 +10,21 @@
             "default": "password",
             "description": "The type of authentication to use. When 'password' is selected, code-server will auto-generate a password. 'none' disables authentication entirely."
         },
+        "cert": {
+            "type": "string",
+            "default": "",
+            "description": "Path to certificate. A self signed certificate is generated if none is provided."
+        },
+        "certHost": {
+            "type": "string",
+            "default": "",
+            "description": "hostname to use when generating a self signed certificate."
+        },
+        "certKey": {
+            "type": "string",
+            "default": "",
+            "description": "path to certificate key when using non-generated cert."
+        },
         "disableFileDownloads": {
             "type": "boolean",
             "default": false,

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -56,18 +56,15 @@ fi
 CERT_FLAGS=()
 
 if [[ -n "$CERT" ]]; then
-    CERT_FLAGS+=(--cert)
-    CERT_FLAGS+=("$CERT")
+    CERT_FLAGS+=(--cert "$CERT")
 fi
 
 if [[ -n "$CERTHOST" ]]; then
-    CERT_FLAGS+=(--cert-host)
-    CERT_FLAGS+=("$CERTHOST")
+    CERT_FLAGS+=(--cert-host "$CERTHOST")
 fi
 
 if [[ -n "$CERTKEY" ]]; then
-    CERT_FLAGS+=(--cert-key)
-    CERT_FLAGS+=("$CERTKEY")
+    CERT_FLAGS+=(--cert-key "$CERTKEY")
 fi
 
 cat > /usr/local/bin/code-server-entrypoint \

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -53,14 +53,32 @@ if [[ "$DISABLEWORKSPACETRUST" == "true" ]]; then
     DISABLE_FLAGS+=(--disable-workspace-trust)
 fi
 
+CERT_FLAGS=()
+
+if [[ -n "$CERT" ]]; then
+    CERT_FLAGS+=(--cert)
+    CERT_FLAGS+=("$CERT")
+fi
+
+if [[ -n "$CERTHOST" ]]; then
+    CERT_FLAGS+=(--cert-host)
+    CERT_FLAGS+=("$CERTHOST")
+fi
+
+if [[ -n "$CERTKEY" ]]; then
+    CERT_FLAGS+=(--cert-key)
+    CERT_FLAGS+=("$CERTKEY")
+fi
+
 cat > /usr/local/bin/code-server-entrypoint \
 << EOF
 #!/usr/bin/env bash
 set -e
 
 $(declare -p DISABLE_FLAGS)
+$(declare -p CERT_FLAGS)
 
-su $_REMOTE_USER -c 'code-server --auth "$AUTH" --bind-addr "$HOST:$PORT" "\${DISABLE_FLAGS[@]}" "$CODE_SERVER_WORKSPACE"'
+su $_REMOTE_USER -c 'code-server --auth "$AUTH" --bind-addr "$HOST:$PORT" "\${DISABLE_FLAGS[@]}" "\${CERT_FLAGS[@]}" "$CODE_SERVER_WORKSPACE"'
 EOF
 
 chmod +x /usr/local/bin/code-server-entrypoint

--- a/test/code-server/code-server-cert-host.sh
+++ b/test/code-server/code-server-cert-host.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server cert-host" grep '"--cert-host".*"coder.com"' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-cert.sh
+++ b/test/code-server/code-server-cert.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+cat /usr/local/bin/code-server-entrypoint
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server cert" grep '"--cert".*"/path/to/cert.pem"' < /usr/local/bin/code-server-entrypoint
+check "code-server cert-key" grep '"--cert-key".*"/path/to/key.pem"' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/scenarios.json
+++ b/test/code-server/scenarios.json
@@ -124,5 +124,22 @@
                 "disableWorkspaceTrust": true
             }
         }
+    },
+    "code-server-cert": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "cert": "/path/to/cert.pem",
+                "certKey": "/path/to/key.pem"
+            }
+        }
+    },
+    "code-server-cert-host": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "certHost": "coder.com"
+            }
+        }
     }
 }


### PR DESCRIPTION
Add new configuration options for custom SSL certificates:
- `cert`: Path to certificate
- `certKey`: Path to certificate key
- `certHost`: Hostname for self-signed certificate