### PR TITLE
feat: support more cli options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	devcontainer features test
+	devcontainer features test --filter "$$DEVCONTAINER_FEATURE_TEST_FILTER"
 
 .PHONY: docs
 docs: src/code-server/README.md

--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -33,6 +33,7 @@ VS Code in the browser
 | locale | Set VS Code display language and language shown on the login page. Format should be an IETF language tag (e.g., 'en', 'fr', 'zh-CN'). | string | - |
 | logFile | Path to a file to send stdout and stderr logs to from code-server. | string | /tmp/code-server.log |
 | port | The port to bind to for the code-server. | string | 8080 |
+| proxyDomain | Domain used for proxying ports. | string | - |
 | socket | Path to a socket. When specified, host and port will be ignored. | string | - |
 | socketMode | File mode of the socket when using the socket option. | string | - |
 | trustedOrigins | Comma-separated list of trusted-origins to disable origin check for. Useful if not able to access reverse proxy configuration. | string | - |

--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -27,6 +27,7 @@ VS Code in the browser
 | disableTelemetry | Disable telemetry reporting. | boolean | false |
 | disableUpdateCheck | Disable update check. Without this flag, code-server checks every 6 hours against the latest GitHub release and notifies once a week when updates are available. | boolean | false |
 | disableWorkspaceTrust | Disable Workspace Trust feature. This only affects the current session. | boolean | false |
+| enableProposedAPI | Comma-separated list of VS Code extension IDs to enable proposed API features for. | string | - |
 | extensions | Comma-separated list of VS Code extensions to install. Format: 'publisher.extension[@version]' (e.g., 'ms-python.python,ms-azuretools.vscode-docker'). | string | - |
 | host | The address to bind to for the code-server. Use '0.0.0.0' to listen on all interfaces. | string | 127.0.0.1 |
 | locale | Set VS Code display language and language shown on the login page. Format should be an IETF language tag (e.g., 'en', 'fr', 'zh-CN'). | string | - |

--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -18,8 +18,8 @@ VS Code in the browser
 | appName | The name to use in branding. Will be shown in titlebar and welcome message. | string | - |
 | auth | The type of authentication to use. When 'password' is selected, code-server will auto-generate a password. 'none' disables authentication entirely. | string | password |
 | cert | Path to certificate. A self signed certificate is generated if none is provided. | string | - |
-| certHost | hostname to use when generating a self signed certificate. | string | - |
-| certKey | path to certificate key when using non-generated cert. | string | - |
+| certHost | Hostname to use when generating a self signed certificate. | string | - |
+| certKey | Path to certificate key when using non-generated cert. | string | - |
 | disableFileDownloads | Disable file downloads from Code. When enabled, users will not be able to download files from the editor. | boolean | false |
 | disableFileUploads | Disable file uploads to Code. When enabled, users will not be able to upload files to the editor. | boolean | false |
 | disableGettingStartedOverride | Disable the coder/coder override in the Help: Getting Started page. | boolean | false |
@@ -34,7 +34,9 @@ VS Code in the browser
 | port | The port to bind to for the code-server. | string | 8080 |
 | socket | Path to a socket. When specified, host and port will be ignored. | string | - |
 | socketMode | File mode of the socket when using the socket option. | string | - |
+| verbose | Enable verbose logging. | boolean | false |
 | version | The version of code-server to install. If empty, installs the latest version. | string | - |
+| welcomeText | Text to show on login page. | string | - |
 | workspace | Path to the workspace or folder to open on startup. Can be a directory or a .code-workspace file. | string | - |
 
 

--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -15,6 +15,7 @@ VS Code in the browser
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
+| appName | The name to use in branding. Will be shown in titlebar and welcome message. | string | - |
 | auth | The type of authentication to use. When 'password' is selected, code-server will auto-generate a password. 'none' disables authentication entirely. | string | password |
 | cert | Path to certificate. A self signed certificate is generated if none is provided. | string | - |
 | certHost | hostname to use when generating a self signed certificate. | string | - |

--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -28,6 +28,7 @@ VS Code in the browser
 | disableWorkspaceTrust | Disable Workspace Trust feature. This only affects the current session. | boolean | false |
 | extensions | Comma-separated list of VS Code extensions to install. Format: 'publisher.extension[@version]' (e.g., 'ms-python.python,ms-azuretools.vscode-docker'). | string | - |
 | host | The address to bind to for the code-server. Use '0.0.0.0' to listen on all interfaces. | string | 127.0.0.1 |
+| locale | Set VS Code display language and language shown on the login page. Format should be an IETF language tag (e.g., 'en', 'fr', 'zh-CN'). | string | - |
 | logFile | Path to a file to send stdout and stderr logs to from code-server. | string | /tmp/code-server.log |
 | port | The port to bind to for the code-server. | string | 8080 |
 | socket | Path to a socket. When specified, host and port will be ignored. | string | - |

--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -34,6 +34,7 @@ VS Code in the browser
 | port | The port to bind to for the code-server. | string | 8080 |
 | socket | Path to a socket. When specified, host and port will be ignored. | string | - |
 | socketMode | File mode of the socket when using the socket option. | string | - |
+| trustedOrigins | Comma-separated list of trusted-origins to disable origin check for. Useful if not able to access reverse proxy configuration. | string | - |
 | verbose | Enable verbose logging. | boolean | false |
 | version | The version of code-server to install. If empty, installs the latest version. | string | - |
 | welcomeText | Text to show on login page. | string | - |

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -95,6 +95,11 @@
             "default": "8080",
             "description": "The port to bind to for the code-server."
         },
+        "proxyDomain": {
+            "type": "string",
+            "default": "",
+            "description": "Domain used for proxying ports."
+        },
         "socket": {
             "type": "string",
             "default": "",

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -65,6 +65,11 @@
             "default": false,
             "description": "Disable Workspace Trust feature. This only affects the current session."
         },
+        "enableProposedAPI": {
+            "type": "string",
+            "default": "",
+            "description": "Comma-separated list of VS Code extension IDs to enable proposed API features for."
+        },
         "extensions": {
             "type": "string",
             "default": "",

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -4,6 +4,11 @@
     "version": "1.0.0",
     "description": "VS Code in the browser",
     "options": {
+        "appName": {
+            "type": "string",
+            "default": "",
+            "description": "The name to use in branding. Will be shown in titlebar and welcome message."
+        },
         "auth": {
             "type": "string",
             "enum": ["password", "none"],
@@ -69,6 +74,11 @@
             "type": "string",
             "default": "127.0.0.1",
             "description": "The address to bind to for the code-server. Use '0.0.0.0' to listen on all interfaces."
+        },
+        "locale": {
+            "type": "string",
+            "default": "",
+            "description": "Set VS Code display language and language shown on the login page. Format should be an IETF language tag (e.g., 'en', 'fr', 'zh-CN')."
         },
         "logFile": {
             "type": "string",

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -100,6 +100,11 @@
             "default": "",
             "description": "File mode of the socket when using the socket option."
         },
+        "verbose": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable verbose logging."
+        },
         "version": {
             "type": "string",
             "default": "",

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -23,12 +23,12 @@
         "certHost": {
             "type": "string",
             "default": "",
-            "description": "hostname to use when generating a self signed certificate."
+            "description": "Hostname to use when generating a self signed certificate."
         },
         "certKey": {
             "type": "string",
             "default": "",
-            "description": "path to certificate key when using non-generated cert."
+            "description": "Path to certificate key when using non-generated cert."
         },
         "disableFileDownloads": {
             "type": "boolean",

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -100,6 +100,11 @@
             "default": "",
             "description": "File mode of the socket when using the socket option."
         },
+        "trustedOrigins": {
+            "type": "string",
+            "default": "",
+            "description": "Comma-separated list of trusted-origins to disable origin check for. Useful if not able to access reverse proxy configuration."
+        },
         "verbose": {
             "type": "boolean",
             "default": false,

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -105,6 +105,11 @@
             "default": "",
             "description": "The version of code-server to install. If empty, installs the latest version."
         },
+        "welcomeText": {
+            "type": "string",
+            "default": "",
+            "description": "Text to show on login page."
+        },
         "workspace": {
             "type": "string",
             "default": "",

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -10,7 +10,6 @@ fi
 curl -fsSL https://code-server.dev/install.sh | sh -s -- $CODE_SERVER_INSTALL_ARGS
 
 IFS=',' read -ra extensions <<<"$EXTENSIONS"
-declare -p extensions
 
 for extension in "${extensions[@]}"
 do
@@ -92,14 +91,12 @@ if [[ "$VERBOSE" == "true" ]]; then
 fi
 
 IFS=',' read -ra trusted_origins <<<"$TRUSTEDORIGINS"
-declare -p trusted_origins
 
 for trusted_origin in "${trusted_origins[@]}"; do
     FLAGS+=(--trusted-origins "$trusted_origin")
 done
 
 IFS=',' read -ra proposed_api_extensions <<<"$ENABLEPROPOSEDAPI"
-declare -p proposed_api_extensions
 
 for extension in "${proposed_api_extensions[@]}"; do
     FLAGS+=(--enable-proposed-api "$extension")

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -83,6 +83,10 @@ if [[ -n "$APPNAME" ]]; then
 	FLAGS+=(--app-name "$APPNAME")
 fi
 
+if [[ -n "$WELCOMETEXT" ]]; then
+    FLAGS+=(--welcome-text "$WELCOMETEXT")
+fi
+
 cat > /usr/local/bin/code-server-entrypoint <<EOF
 #!/usr/bin/env bash
 set -e

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -105,6 +105,10 @@ for extension in "${proposed_api_extensions[@]}"; do
     FLAGS+=(--enable-proposed-api "$extension")
 done
 
+if [[ "$PROXYDOMAIN" ]]; then
+    FLAGS+=(--proxy-domain "$PROXYDOMAIN")
+fi
+
 cat > /usr/local/bin/code-server-entrypoint <<EOF
 #!/usr/bin/env bash
 set -e

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -75,6 +75,14 @@ if [[ -n "$SOCKETMODE" ]]; then
     FLAGS+=(--socket-mode "$SOCKETMODE")
 fi
 
+if [[ -n "$LOCALE" ]]; then
+    FLAGS+=(--locale "$LOCALE")
+fi
+
+if [[ -n "$APPNAME" ]]; then
+	FLAGS+=(--app-name "$APPNAME")
+fi
+
 cat > /usr/local/bin/code-server-entrypoint <<EOF
 #!/usr/bin/env bash
 set -e

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -87,6 +87,10 @@ if [[ -n "$WELCOMETEXT" ]]; then
     FLAGS+=(--welcome-text "$WELCOMETEXT")
 fi
 
+if [[ "$VERBOSE" == "true" ]]; then
+    FLAGS+=(--verbose)
+fi
+
 cat > /usr/local/bin/code-server-entrypoint <<EOF
 #!/usr/bin/env bash
 set -e

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -98,6 +98,13 @@ for trusted_origin in "${trusted_origins[@]}"; do
     FLAGS+=(--trusted-origins "$trusted_origin")
 done
 
+IFS=',' read -ra proposed_api_extensions <<<"$ENABLEPROPOSEDAPI"
+declare -p proposed_api_extensions
+
+for extension in "${proposed_api_extensions[@]}"; do
+    FLAGS+=(--enable-proposed-api "$extension")
+done
+
 cat > /usr/local/bin/code-server-entrypoint <<EOF
 #!/usr/bin/env bash
 set -e

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -91,6 +91,13 @@ if [[ "$VERBOSE" == "true" ]]; then
     FLAGS+=(--verbose)
 fi
 
+IFS=',' read -ra trusted_origins <<<"$TRUSTEDORIGINS"
+declare -p trusted_origins
+
+for trusted_origin in "${trusted_origins[@]}"; do
+    FLAGS+=(--trusted-origins "$trusted_origin")
+done
+
 cat > /usr/local/bin/code-server-entrypoint <<EOF
 #!/usr/bin/env bash
 set -e

--- a/test/code-server/code-server-app-name.sh
+++ b/test/code-server/code-server-app-name.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server locale" grep '"--app-name".*"My Code Server"' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-enable-proposed-api.sh
+++ b/test/code-server/code-server-enable-proposed-api.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server enable-proposed-api" grep '"--enable-proposed-api".*"rust-lang.rust-analyzer".*"--enable-proposed-api".*"ms-python.python"' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-locale.sh
+++ b/test/code-server/code-server-locale.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server locale" grep '"--locale".*"fr"' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-proxy-domain.sh
+++ b/test/code-server/code-server-proxy-domain.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server proxy-domain" grep '"--proxy-domain".*"dev.coder.com"' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-trusted-origins.sh
+++ b/test/code-server/code-server-trusted-origins.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server trusted-origins" grep '"--trusted-origins".*"dev.coder.com".*"--trusted-origins".*"coder.com"' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-verbose.sh
+++ b/test/code-server/code-server-verbose.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server verbose" grep '"--verbose"' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-welcome-text.sh
+++ b/test/code-server/code-server-welcome-text.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server welcome-text" grep '"--welcome-text".*"Some Welcome Text"' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/scenarios.json
+++ b/test/code-server/scenarios.json
@@ -219,5 +219,13 @@
                 ]
             }
         }
+    },
+    "code-server-proxy-domain": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "proxyDomain": "dev.coder.com"
+            }
+        }
     }
 }

--- a/test/code-server/scenarios.json
+++ b/test/code-server/scenarios.json
@@ -192,5 +192,13 @@
                 "welcomeText": "Some Welcome Text"
             }
         }
+    },
+    "code-server-verbose": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "verbose": true
+            }
+        }
     }
 }

--- a/test/code-server/scenarios.json
+++ b/test/code-server/scenarios.json
@@ -184,5 +184,13 @@
                 "appName": "My Code Server"
             }
         }
+    },
+    "code-server-welcome-text": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "welcomeText": "Some Welcome Text"
+            }
+        }
     }
 }

--- a/test/code-server/scenarios.json
+++ b/test/code-server/scenarios.json
@@ -208,5 +208,16 @@
                 "trustedOrigins": ["dev.coder.com", "coder.com"]
             }
         }
+    },
+    "code-server-enable-proposed-api": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "enableProposedAPI": [
+                    "rust-lang.rust-analyzer",
+                    "ms-python.python"
+                ]
+            }
+        }
     }
 }

--- a/test/code-server/scenarios.json
+++ b/test/code-server/scenarios.json
@@ -200,5 +200,13 @@
                 "verbose": true
             }
         }
+    },
+    "code-server-trusted-origins": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "trustedOrigins": ["dev.coder.com", "coder.com"]
+            }
+        }
     }
 }

--- a/test/code-server/scenarios.json
+++ b/test/code-server/scenarios.json
@@ -168,5 +168,21 @@
                 "logFile": "/tmp/code-server-log-file.log"
             }
         }
+    },
+    "code-server-locale": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "locale": "fr"
+            }
+        }
+    },
+    "code-server-app-name": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "appName": "My Code Server"
+            }
+        }
     }
 }


### PR DESCRIPTION
Add support for:
- `--locale`
- `--app-name`
- `--welcome-text`
- `--verbose`
- `--trusted-origins`
- `--enable-proposed-api`
- `--proxy-domain`