### PR TITLE
feat: add `passwordFile`, `hashedPasswordFile`, `githubAuthTokenFile` and `absProxyBasePath` options

### DIFF
--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -15,6 +15,7 @@ VS Code in the browser
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
+| absProxyBasePath | The base path to prefix to all absproxy requests | string | - |
 | appName | The name to use in branding. Will be shown in titlebar and welcome message. | string | - |
 | auth | The type of authentication to use. When 'password' is selected, code-server will auto-generate a password. 'none' disables authentication entirely. | string | password |
 | cert | Path to certificate. A self signed certificate is generated if none is provided. | string | - |

--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -29,9 +29,11 @@ VS Code in the browser
 | disableWorkspaceTrust | Disable Workspace Trust feature. This only affects the current session. | boolean | false |
 | enableProposedAPI | Comma-separated list of VS Code extension IDs to enable proposed API features for. | string | - |
 | extensions | Comma-separated list of VS Code extensions to install. Format: 'publisher.extension[@version]' (e.g., 'ms-python.python,ms-azuretools.vscode-docker'). | string | - |
+| hashedPasswordFile | Path to a file containing the hashed password used for authentication. The password should be hashed with argon2 and be in the encoded form. This takes priority over `passwordFile`. | string | - |
 | host | The address to bind to for the code-server. Use '0.0.0.0' to listen on all interfaces. | string | 127.0.0.1 |
 | locale | Set VS Code display language and language shown on the login page. Format should be an IETF language tag (e.g., 'en', 'fr', 'zh-CN'). | string | - |
 | logFile | Path to a file to send stdout and stderr logs to from code-server. | string | /tmp/code-server.log |
+| passwordFile | Path to a file containing the password used for authentication. | string | - |
 | port | The port to bind to for the code-server. | string | 8080 |
 | proxyDomain | Domain used for proxying ports. | string | - |
 | socket | Path to a socket. When specified, host and port will be ignored. | string | - |

--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -29,6 +29,7 @@ VS Code in the browser
 | disableWorkspaceTrust | Disable Workspace Trust feature. This only affects the current session. | boolean | false |
 | enableProposedAPI | Comma-separated list of VS Code extension IDs to enable proposed API features for. | string | - |
 | extensions | Comma-separated list of VS Code extensions to install. Format: 'publisher.extension[@version]' (e.g., 'ms-python.python,ms-azuretools.vscode-docker'). | string | - |
+| githubAuthTokenFile | Path to a file containing your GitHub auth token. | string | - |
 | hashedPasswordFile | Path to a file containing the hashed password used for authentication. The password should be hashed with argon2 and be in the encoded form. This takes priority over `passwordFile`. | string | - |
 | host | The address to bind to for the code-server. Use '0.0.0.0' to listen on all interfaces. | string | 127.0.0.1 |
 | locale | Set VS Code display language and language shown on the login page. Format should be an IETF language tag (e.g., 'en', 'fr', 'zh-CN'). | string | - |

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -75,6 +75,11 @@
             "default": "",
             "description": "Comma-separated list of VS Code extensions to install. Format: 'publisher.extension[@version]' (e.g., 'ms-python.python,ms-azuretools.vscode-docker')."
         },
+        "hashedPasswordFile": {
+            "type": "string",
+            "default": "",
+            "description": "Path to a file containing the hashed password used for authentication. The password should be hashed with argon2 and be in the encoded form. This takes priority over `passwordFile`."
+        },
         "host": {
             "type": "string",
             "default": "127.0.0.1",
@@ -89,6 +94,11 @@
             "type": "string",
             "default": "/tmp/code-server.log",
             "description": "Path to a file to send stdout and stderr logs to from code-server."
+        },
+        "passwordFile": {
+            "type": "string",
+            "default": "",
+            "description": "Path to a file containing the password used for authentication."
         },
         "port": {
             "type": "string",

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -75,6 +75,11 @@
             "default": "",
             "description": "Comma-separated list of VS Code extensions to install. Format: 'publisher.extension[@version]' (e.g., 'ms-python.python,ms-azuretools.vscode-docker')."
         },
+        "githubAuthTokenFile": {
+            "type": "string",
+            "default": "",
+            "description": "Path to a file containing your GitHub auth token."
+        },
         "hashedPasswordFile": {
             "type": "string",
             "default": "",

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -4,6 +4,11 @@
     "version": "1.0.0",
     "description": "VS Code in the browser",
     "options": {
+        "absProxyBasePath": {
+            "type": "string",
+            "default": "",
+            "description": "The base path to prefix to all absproxy requests"
+        },
         "appName": {
             "type": "string",
             "default": "",

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -121,15 +121,15 @@ fi
 $(declare -p FLAGS)
 
 if [[ -f "$PASSWORDFILE" ]]; then
-	export PASSWORD="\$(cat '$PASSWORDFILE')"
+	export PASSWORD="\$(<"$PASSWORDFILE")"
 fi
 
 if [[ -f "$HASHEDPASSWORDFILE" ]]; then
-	export HASHED_PASSWORD="\$(cat '$HASHEDPASSWORDFILE')"
+	export HASHED_PASSWORD="\$(<"$HASHEDPASSWORDFILE")"
 fi
 
 if [[ -f "$GITHUBAUTHTOKENFILE" ]]; then
-    export GITHUB_TOKEN="\$(cat '$GITHUBAUTHTOKENFILE')"
+    export GITHUB_TOKEN="\$(<"$GITHUBAUTHTOKENFILE")"
 fi
 
 code-server "\${FLAGS[@]}" "$CODE_SERVER_WORKSPACE" >"$LOGFILE" 2>&1

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -116,6 +116,14 @@ fi
 
 $(declare -p FLAGS)
 
+if [[ -f "$PASSWORDFILE" ]]; then
+	export PASSWORD="\$(cat '$PASSWORDFILE')"
+fi
+
+if [[ -f "$HASHEDPASSWORDFILE" ]]; then
+	export HASHED_PASSWORD="\$(cat '$HASHEDPASSWORDFILE')"
+fi
+
 code-server "\${FLAGS[@]}" "$CODE_SERVER_WORKSPACE" >"$LOGFILE" 2>&1
 EOF
 

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -106,6 +106,10 @@ if [[ "$PROXYDOMAIN" ]]; then
     FLAGS+=(--proxy-domain "$PROXYDOMAIN")
 fi
 
+if [[ "$ABSPROXYBASEPATH" ]]; then
+    FLAGS+=(--abs-proxy-base-path "$ABSPROXYBASEPATH")
+fi
+
 cat > /usr/local/bin/code-server-entrypoint <<EOF
 #!/usr/bin/env bash
 set -e

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -124,6 +124,10 @@ if [[ -f "$HASHEDPASSWORDFILE" ]]; then
 	export HASHED_PASSWORD="\$(cat '$HASHEDPASSWORDFILE')"
 fi
 
+if [[ -f "$GITHUBAUTHTOKENFILE" ]]; then
+    export GITHUB_TOKEN="\$(cat '$GITHUBAUTHTOKENFILE')"
+fi
+
 code-server "\${FLAGS[@]}" "$CODE_SERVER_WORKSPACE" >"$LOGFILE" 2>&1
 EOF
 

--- a/test/code-server/code-server-abs-proxy-base-path.sh
+++ b/test/code-server/code-server-abs-proxy-base-path.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server locale" grep '"--abs-proxy-base-path".*"/user/123/workspace"' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-github-auth-token-file.sh
+++ b/test/code-server/code-server-github-auth-token-file.sh
@@ -10,7 +10,7 @@ check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@127.0.0.1:8080"
 
 cat /tmp/code-server.log
-check "code-server github-auth-token-file" grep $'export GITHUB_TOKEN="$(cat \'/tmp/code-server-github-auth-token\')"' < /usr/local/bin/code-server-entrypoint
+check "code-server github-auth-token-file" grep 'export GITHUB_TOKEN="$(<"/tmp/code-server-github-auth-token")"' < /usr/local/bin/code-server-entrypoint
 
 # Report results
 reportResults

--- a/test/code-server/code-server-github-auth-token-file.sh
+++ b/test/code-server/code-server-github-auth-token-file.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+cat /tmp/code-server.log
+check "code-server github-auth-token-file" grep $'export GITHUB_TOKEN="$(cat \'/tmp/code-server-github-auth-token\')"' < /usr/local/bin/code-server-entrypoint
+
+# Report results
+reportResults

--- a/test/code-server/code-server-github-auth-token-file/Dockerfile
+++ b/test/code-server/code-server-github-auth-token-file/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN su vscode -c 'echo "github auth token" > /tmp/code-server-github-auth-token'

--- a/test/code-server/code-server-hashed-password-file.sh
+++ b/test/code-server/code-server-hashed-password-file.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server hashed-password-file" grep $'export HASHED_PASSWORD="$(cat \'/tmp/code-server-hashed-password\')"' < /usr/local/bin/code-server-entrypoint
+check "code-server hashed-password" grep 'Using password from $HASHED_PASSWORD' < /tmp/code-server.log
+
+# Report results
+reportResults

--- a/test/code-server/code-server-hashed-password-file.sh
+++ b/test/code-server/code-server-hashed-password-file.sh
@@ -9,7 +9,7 @@ check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@127.0.0.1:8080"
 
-check "code-server hashed-password-file" grep $'export HASHED_PASSWORD="$(cat \'/tmp/code-server-hashed-password\')"' < /usr/local/bin/code-server-entrypoint
+check "code-server hashed-password-file" grep 'export HASHED_PASSWORD="$(<"/tmp/code-server-hashed-password")"' < /usr/local/bin/code-server-entrypoint
 check "code-server hashed-password" grep 'Using password from $HASHED_PASSWORD' < /tmp/code-server.log
 
 # Report results

--- a/test/code-server/code-server-hashed-password-file/Dockerfile
+++ b/test/code-server/code-server-hashed-password-file/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN su vscode -c 'echo "\$argon2id\$v=19\$m=16,t=2,p=1\$c2FtcGxlc2FsdA\$YBn10Qizrh/i2jf/rPOCCA" > /tmp/code-server-hashed-password'

--- a/test/code-server/code-server-password-file.sh
+++ b/test/code-server/code-server-password-file.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+check "code-server version" code-server --version
+check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
+check "code-server listening" lsof -i "@127.0.0.1:8080"
+
+check "code-server password-file" grep $'export PASSWORD="$(cat \'/tmp/code-server-password\')"' < /usr/local/bin/code-server-entrypoint
+check "code-server password" grep 'Using password from $PASSWORD' < /tmp/code-server.log
+
+# Report results
+reportResults

--- a/test/code-server/code-server-password-file.sh
+++ b/test/code-server/code-server-password-file.sh
@@ -9,7 +9,7 @@ check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@127.0.0.1:8080"
 
-check "code-server password-file" grep $'export PASSWORD="$(cat \'/tmp/code-server-password\')"' < /usr/local/bin/code-server-entrypoint
+check "code-server password-file" grep $'export PASSWORD="$(<"/tmp/code-server-password")"' < /usr/local/bin/code-server-entrypoint
 check "code-server password" grep 'Using password from $PASSWORD' < /tmp/code-server.log
 
 # Report results

--- a/test/code-server/code-server-password-file/Dockerfile
+++ b/test/code-server/code-server-password-file/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN su vscode -c "echo 'some sample password' > /tmp/code-server-password"

--- a/test/code-server/scenarios.json
+++ b/test/code-server/scenarios.json
@@ -247,5 +247,15 @@
                 "hashedPasswordFile": "/tmp/code-server-hashed-password"
             }
         }
+    },
+    "code-server-github-auth-token-file": {
+        "build": {
+            "dockerfile": "Dockerfile"
+        },
+        "features": {
+            "code-server": {
+                "githubAuthTokenFile": "/tmp/code-server-github-auth-token"
+            }
+        }
     }
 }

--- a/test/code-server/scenarios.json
+++ b/test/code-server/scenarios.json
@@ -257,5 +257,13 @@
                 "githubAuthTokenFile": "/tmp/code-server-github-auth-token"
             }
         }
+    },
+    "code-server-abs-proxy-base-path": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "code-server": {
+                "absProxyBasePath": "/user/123/workspace"
+            }
+        }
     }
 }

--- a/test/code-server/scenarios.json
+++ b/test/code-server/scenarios.json
@@ -227,5 +227,25 @@
                 "proxyDomain": "dev.coder.com"
             }
         }
+    },
+    "code-server-password-file": {
+        "build": {
+            "dockerfile": "Dockerfile"
+        },
+        "features": {
+            "code-server": {
+                "passwordFile": "/tmp/code-server-password"
+            }
+        }
+    },
+    "code-server-hashed-password-file": {
+        "build": {
+            "dockerfile": "Dockerfile"
+        },
+        "features": {
+            "code-server": {
+                "hashedPasswordFile": "/tmp/code-server-hashed-password"
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/462

Adds the final four options
- `passwordFile`
- `hashedPasswordFile`
- `githubAuthTokenFile`
- `absProxyBasePath`

The decision to pass credentials via a file instead of embedding them directly in the `devcontainer.json` is to allow people the ability to not commit the password to source control.

With these final four options added we should have feature parity with the CLI.