### PR TITLE
fix: install extensions under remote user not root user

### DIFF
--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -53,4 +53,4 @@ VS Code in the browser ([code-server](https://github.com/coder/code-server))
 
 ---
 
-_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/coder/devcontainer-features/blob/main/src/code-server/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._
+_Note: This file was auto-generated from the [devcontainer-feature.json](devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/code-server/install.sh
+++ b/src/code-server/install.sh
@@ -9,12 +9,17 @@ fi
 
 curl -fsSL https://code-server.dev/install.sh | sh -s -- $CODE_SERVER_INSTALL_ARGS
 
-IFS=',' read -ra extensions <<<"$EXTENSIONS"
+if [[ -n "$EXTENSIONS" ]]; then
+    IFS=',' read -ra extensions <<<"$EXTENSIONS"
 
-for extension in "${extensions[@]}"
-do
-    code-server --install-extension "$extension"
-done
+    for extension in "${extensions[@]}"
+    do
+        if ! su "$_REMOTE_USER" -c "code-server --install-extension '$extension'"; then
+            echo "ERROR: Failed to install extension '$extension' as user '$_REMOTE_USER'" >&2
+            exit 1
+        fi
+    done
+fi
 
 CODE_SERVER_WORKSPACE="$_REMOTE_USER_HOME"
 

--- a/test/code-server/code-server-extensions.sh
+++ b/test/code-server/code-server-extensions.sh
@@ -9,10 +9,13 @@ check "code-server version" code-server --version
 check "code-server running" pgrep -f 'code-server/lib/node.*/code-server'
 check "code-server listening" lsof -i "@0.0.0.0:8080"
 
-extensions=$(sudo code-server --list-extensions)
+# Verify extensions are installed under the remoteUser's home, not root's.
+# See: https://github.com/coder/devcontainer-features/issues/18
+extensions_dir=/home/vscode/.local/share/code-server/extensions
 
-check "code-server extensions [rust-lang.rust-analyzer]" grep 'rust-lang.rust-analyzer\>' <<<"$extensions"
-check "code-server extensions [ms-python.python]"        grep 'ms-python.python\>'        <<<"$extensions"
+check "rust-analyzer installed under remoteUser" ls "$extensions_dir"/rust-lang.rust-analyzer-*
+check "python installed under remoteUser"        ls "$extensions_dir"/ms-python.python-*
+check "extensions not installed under root"      test ! -d /root/.local/share/code-server/extensions
 
 # Report results
 reportResults


### PR DESCRIPTION
Closes #18 

Make sure to install extensions under the `$_REMOTE_USER` instead of the root user.