### PR TITLE
chore: bump code-server version to 2.0.0

### DIFF
--- a/src/code-server/README.md
+++ b/src/code-server/README.md
@@ -7,7 +7,7 @@ VS Code in the browser ([code-server](https://github.com/coder/code-server))
 
 ```json
 "features": {
-    "ghcr.io/coder/devcontainer-features/code-server:1": {}
+    "ghcr.io/coder/devcontainer-features/code-server:2": {}
 }
 ```
 

--- a/src/code-server/devcontainer-feature.json
+++ b/src/code-server/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "code-server",
     "id": "code-server",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "description": "VS Code in the browser ([code-server](https://github.com/coder/code-server))",
     "options": {
         "absProxyBasePath": {


### PR DESCRIPTION
Bump the major version as discussed in https://github.com/coder/devcontainer-features/pull/19